### PR TITLE
Fix padding between bottom essentials and media widget

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -269,9 +269,13 @@
             position: relative !important;
             margin-top: auto !important;
             padding-top: 8px !important;
-            padding-bottom: 10px !important;
         }
 
+        /* Adds padding-bottom only when media controls are visible */
+        #zen-media-controls-toolbar:not([hidden]) ~ .zen-essentials-container {
+            padding-bottom: 10px !important;
+        }
+        
         #zen-essentials-container, #zen-essentials {
             order: 999 !important;
         }


### PR DESCRIPTION
Added padding-bottom: 10px to essentials container. This fixes the issue of the essentials being too close to the media player widget when the essentials are on the bottom.

![image](https://github.com/user-attachments/assets/cee00998-55ec-4726-a49b-4f5e5461f134)

![image](https://github.com/user-attachments/assets/25d0f9be-1e6d-4ba6-8d60-d5ac0ab04ffd)
