### PR TITLE
Adds an option to disable the current workspace indicator's icon

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -488,7 +488,13 @@
     }
 
     /* current workspace icons size */
-    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="small"]) {
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="disabled"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 0 !important;
+        }
+    }
+
+	:root:has(#theme-SuperPins[uc-workspace-current-icon-size="small"]) {
         .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
             font-size: 12px !important;
         }

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -317,6 +317,10 @@
         "placeholder": "Default",
         "options": [
             {
+                "label": "Disabled",
+                "value": "disabled"
+            },
+			{
                 "label": "Small",
                 "value": "small"
             },


### PR DESCRIPTION
Currently, you can only completely disable the workspace indicator, or to decrease/increase its icon size. This adds the option to disable just the icon.

Default pos.:
<img width="313" height="334" alt="image" src="https://github.com/user-attachments/assets/cf5d151f-b212-4070-8a75-45f904365f19" />
Bottom pos.:
<img width="314" height="115" alt="image" src="https://github.com/user-attachments/assets/d25c158a-8f49-4b53-9dcf-9eedc21439ac" />
Settings:
<img width="709" height="202" alt="image" src="https://github.com/user-attachments/assets/a3d25b7f-3a0a-4e32-bfc0-e32b2dc65182" />