### PR TITLE
Update chrome.css (fixes #69)

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -206,6 +206,10 @@
             }
         }
 
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+            align-items: normal;
+        }
+
         .zen-workspace-pinned-tabs-section:not(:has([zen-dragtarget], zen-folder .tab-group-label-container[zen-dragtarget])) zen-folder[collapsed] .tab-group-container {
             display: none !important;
         }
@@ -630,10 +634,7 @@
 
     @media (-moz-pref("zen.workspaces.indicator-name-center")) {
         .zen-current-workspace-indicator-name {
-            position: absolute;
-            left: 0;
-            text-align: center;
-            width: 100%;
+            justify-content: center;
         }
     }
 


### PR DESCRIPTION
Fixes the workspace name clipping into icon issue (after 1.15)

Also a minor fix: The workspace icon was not perfectly aligned with the text (will attach photos in PR) - a few pixels below what it should be.

| old | new |
|--------|--------|
| <img width="221" height="42" alt="image" src="https://github.com/user-attachments/assets/dadb4a66-c8c8-453a-970e-e6ca79525b04" /> | <img width="227" height="38" alt="image" src="https://github.com/user-attachments/assets/b0c65c20-abbf-45da-9876-d85bd6c882e9" /> | 

<details><summary>Zoomed in analysis:</summary>
<img width="879" height="535" alt="image" src="https://github.com/user-attachments/assets/6294c49f-a496-49a7-9603-2a5cf9adc64b" />
</details> 