### PR TITLE
Fix typo in uc.pins.grid-count implementation

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -175,7 +175,7 @@
             @media (-moz-pref("uc.pins.grid-count")) {
                 #vertical-pinned-tabs-container>.zen-workspace-tabs-section,
                 .zen-workspace-pinned-tabs-section:not(:has([zen-dragtarget], zen-folder .tab-group-label-container[zen-dragtarget])) {
-                    grid-template-columns: repeat(var(auto-fit, --mod-superpins-pins-grid-count), minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
+                    grid-template-columns: repeat(var(--mod-superpins-pins-grid-count), minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
                 }
             }
         }


### PR DESCRIPTION
Hi! I just noticed while using SuperPins that there's a typo that prevents it from limiting the number of items per row unless you're using the view that expands items to fit the row. This should get it working again!