### PR TITLE
fix wrong pinned tab height in closed folder (superpins)

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -673,7 +673,7 @@
 
   @media (-moz-pref("uc.pinned.height")) {
     .zen-workspace-pinned-tabs-section .tabbrowser-tab {
-      height: var(--pins-height) !important;
+      height: var(--pins-height);
     }
   }
 


### PR DESCRIPTION
<img width="248" height="188" alt="image" src="https://github.com/user-attachments/assets/2b94d7b8-7ced-48ab-ba90-8130e0a83dbf" />
<img width="260" height="120" alt="image" src="https://github.com/user-attachments/assets/ba28fe97-c53b-4c3d-af17-93eb9f9826a0" />