### PR TITLE
Superpins: Render pinned folders as a vertical list instead of a grid

### DIFF
--- a/SuperPins/chrome.css
+++ b/SuperPins/chrome.css
@@ -183,7 +183,7 @@
           zen-folder .tab-group-label-container[zen-dragtarget]
         )
       ) {
-        .tabbrowser-tab[pinned] {
+        .tabbrowser-tab[pinned]:not(:where(zen-folder *)) {
           .tab-close-button,
           .tab-reset-button,
           .tab-reset-pin-button,
@@ -202,8 +202,7 @@
           zen-folder .tab-group-label-container[zen-dragtarget]
         )
       ) {
-        &,
-        zen-folder > .tab-group-container {
+        & {
           display: flex !important;
           flex-flow: row wrap !important;
 
@@ -248,8 +247,7 @@
           zen-folder .tab-group-label-container[zen-dragtarget]
         )
       ) {
-        &,
-        zen-folder > .tab-group-container {
+        & {
           grid-template-columns: repeat(
             auto-fit,
             minmax(var(--tab-pinned-min-width-expanded), auto)
@@ -277,8 +275,7 @@
         zen-folder .tab-group-label-container[zen-dragtarget]
       )
     ) {
-      &:has(> :nth-child(3)),
-      zen-folder > .tab-group-container:has(> :nth-child(3)) {
+      &:has(> :nth-child(3)) {
         position: relative !important;
         overflow: visible !important;
         gap: 3px !important;
@@ -304,7 +301,7 @@
         }
       }
 
-      .tab-icon-stack {
+      .tab-icon-stack:not(:where(zen-folder *)) {
         margin-left: 50% !important;
         transform: translateX(-50%) !important;
       }
@@ -317,12 +314,21 @@
         margin: auto !important;
       }
 
-      zen-folder > .tab-group-container:has(> :nth-child(3)) {
+      zen-folder > .tab-group-container {
+        flex-direction: column !important;
+        flex-wrap: nowrap !important;
+        grid-template-columns: unset !important;
+        gap: 0 !important;
         margin-inline-start: 14px !important;
+        max-width: unset !important;
+        writing-mode: horizontal-tb !important;
 
         & > * {
           margin-inline-start: 0 !important;
           margin-left: 0 !important;
+          width: 100% !important;
+          min-width: 0 !important;
+          max-width: none !important;
         }
       }
 


### PR DESCRIPTION
… 1. L186 — Exclude folder tabs from the label/close-button hide rule:

  .tabbrowser-tab[pinned] → .tabbrowser-tab[pinned]:not(:where(zen-folder *))
  2. L206 (uc.pins.auto-grow path) — Drop zen-folder > .tab-group-container from the row-wrap flex rule so folders aren't laid out as wrapped rows.
  3. L251 (no-auto-grow path) — Drop zen-folder > .tab-group-container from the grid layout rule so folders aren't placed in the pin grid.
  4. L279 — Drop zen-folder > .tab-group-container:has(> :nth-child(3)) from the grid sizing/gap rule.
  5. L305 — Don't center-translate icons of folder tabs: .tab-icon-stack → .tab-icon-stack:not(:where(zen-folder *))
  6. L318 — Replace the folder margin-only tweak with a full flex-column layout:
    - selector relaxed: zen-folder > .tab-group-container:has(> :nth-child(3)) → zen-folder > .tab-group-container
    - added: flex-direction: column, flex-wrap: nowrap, grid-template-columns: unset, gap: 0, max-width: unset, writing-mode: horizontal-tb
    - on direct children: added width: 100%, min-width: 0, max-width: none